### PR TITLE
-BCI-652 Chat screen --> open url custom popup: 	1.If i click any url…

### DIFF
--- a/BChat/Conversations/Context Menu/ContextMenuVC+ActionView.swift
+++ b/BChat/Conversations/Context Menu/ContextMenuVC+ActionView.swift
@@ -40,6 +40,9 @@ extension ContextMenuVC {
             if action.title == "Delete" {
                 titleLabel.textColor = Colors.bothRedColor
             }
+            if action.title == "Save" {
+                iconImageView.tintColor = Colors.bothWhiteColor
+            }
             titleLabel.font = Fonts.OpenSans(ofSize: 12)
             // Stack view
             let stackView = UIStackView(arrangedSubviews: [ iconImageView, titleLabel ])

--- a/BChat/Conversations/ConversationVC.swift
+++ b/BChat/Conversations/ConversationVC.swift
@@ -1221,6 +1221,8 @@ final class ConversationVC : BaseVC, ConversationViewModelDelegate, OWSConversat
             self.customizeSlideToOpen.isHidden = true
             CustomSlideView.isFromExpandAttachment = false
         }
+        hideAttachmentExpandedButtons()
+        hideOpenURLView()
     }
     
     override func viewDidDisappear(_ animated: Bool) {
@@ -1760,6 +1762,7 @@ final class ConversationVC : BaseVC, ConversationViewModelDelegate, OWSConversat
     
     // Show open url view
     func showOpenURLView() {
+        snInputView.resignFirstResponder()
         snInputView.isHidden = true
         removeOpenURLViewIfAvailable()
         view.addSubview(openURLView)

--- a/BChat/Conversations/Input View/ExpandingAttachmentsButton.swift
+++ b/BChat/Conversations/Input View/ExpandingAttachmentsButton.swift
@@ -24,7 +24,7 @@ final class ExpandingAttachmentsButton : UIView, InputViewButtonDelegate {
     private lazy var cameraButtonContainerBottomConstraint = cameraButtonContainer.pin(.bottom, to: .bottom, of: self)
     // MARK: UI Components
     lazy var documentButton: InputViewButton = {
-        let result = InputViewButton(icon: #imageLiteral(resourceName: "ic_doc_new"), delegate: self, hasOpaqueBackground: false)
+        let result = InputViewButton(icon: #imageLiteral(resourceName: "ic_doc_new"), delegate: self, hasOpaqueBackground: false, isAttachmentButton: true)
         result.tintColor = UIColor.white
         result.set(.width, to: 36)
         result.set(.height, to: 36)
@@ -34,7 +34,7 @@ final class ExpandingAttachmentsButton : UIView, InputViewButtonDelegate {
     }()
     lazy var documentButtonContainer = container(for: documentButton)
     lazy var libraryButton: InputViewButton = {
-        let result = InputViewButton(icon: #imageLiteral(resourceName: "ic_lib_new"), delegate: self, hasOpaqueBackground: false)
+        let result = InputViewButton(icon: #imageLiteral(resourceName: "ic_lib_new"), delegate: self, hasOpaqueBackground: false, isAttachmentButton: true)
         result.set(.width, to: 36)
         result.set(.height, to: 36)
         result.layer.cornerRadius = 18
@@ -43,7 +43,7 @@ final class ExpandingAttachmentsButton : UIView, InputViewButtonDelegate {
     }()
     lazy var libraryButtonContainer = container(for: libraryButton)
     lazy var cameraButton: InputViewButton = {
-        let result = InputViewButton(icon: #imageLiteral(resourceName: "ic_camera_new"), delegate: self, hasOpaqueBackground: false)
+        let result = InputViewButton(icon: #imageLiteral(resourceName: "ic_camera_new"), delegate: self, hasOpaqueBackground: false, isAttachmentButton: true)
         result.set(.width, to: 36)
         result.set(.height, to: 36)
         result.layer.cornerRadius = 18

--- a/BChat/Conversations/Input View/InputViewButton.swift
+++ b/BChat/Conversations/Input View/InputViewButton.swift
@@ -3,7 +3,6 @@ import UIKit
 final class InputViewButton : UIView {
     private let icon: UIImage
     private let isSendButton: Bool
-//    private let isAudioButton: Bool
     private weak var delegate: InputViewButtonDelegate?
     private let hasOpaqueBackground: Bool
     private lazy var widthConstraint = set(.width, to: InputViewButton.size)
@@ -31,7 +30,6 @@ final class InputViewButton : UIView {
         self.delegate = delegate
         self.hasOpaqueBackground = hasOpaqueBackground
         self.isPayButton = isPayButton
-//        self.isAudioButton = isAudioButton
         super.init(frame: CGRect.zero)
         setUpViewHierarchy()
         self.isAccessibilityElement = true
@@ -50,7 +48,6 @@ final class InputViewButton : UIView {
         if hasOpaqueBackground {
             let backgroundView = UIView()
             backgroundView.backgroundColor = Colors.accent
-          //  backgroundView.alpha = Values.lowOpacity
             addSubview(backgroundView)
             backgroundView.pin(to: self)
             let blurView = UIVisualEffectView(effect: UIBlurEffect(style: .regular))
@@ -60,10 +57,10 @@ final class InputViewButton : UIView {
             let borderColor = (isLightMode ? UIColor.black : UIColor.white).withAlphaComponent(Values.veryLowOpacity)
             layer.borderColor = borderColor.cgColor
         }
-        backgroundView.backgroundColor = isSendButton ? Colors.bothGreenColor : UIColor.clear//Colors.accent : UIColor.clear
+        backgroundView.backgroundColor = isSendButton ? Colors.bothGreenColor : UIColor.clear
         addSubview(backgroundView)
         backgroundView.pin(to: self)
-        layer.cornerRadius = isSendButton ? 24 : 24//isSendButton ? 20 : 6
+        layer.cornerRadius = isSendButton ? 24 : 24
         if isAttachmentButton {
             layer.cornerRadius = 18
         }
@@ -71,19 +68,13 @@ final class InputViewButton : UIView {
         isUserInteractionEnabled = true
         widthConstraint.isActive = true
         heightConstraint.isActive = true
-//        let tint = isSendButton ? UIColor.white : Colors.text
-        let iconImageView = UIImageView(image: icon)//UIImageView(image: icon.withTint(tint))
+        let iconImageView = UIImageView(image: icon)
         iconImageView.contentMode = .scaleAspectFit
         let iconSize = InputViewButton.iconSize
         iconImageView.set(.width, to: iconSize)
         iconImageView.set(.height, to: iconSize)
         addSubview(iconImageView)
-//        if isAudioButton {
-//            iconImageView.pin(.left, to: .left, of: self)
-//            iconImageView.pin(.top, to: .top, of: self, withInset: 10)
-//        } else {
-//            iconImageView.center(in: self)
-//        }
+
         iconImageView.center(in: self)
         
     }
@@ -96,7 +87,7 @@ final class InputViewButton : UIView {
         UIView.animate(withDuration: 0.25) {
             self.layoutIfNeeded()
             self.frame = frame
-            self.layer.cornerRadius = self.isSendButton ? 24 : 24//self.isSendButton ? 20 : 7
+            self.layer.cornerRadius = self.isSendButton ? 24 : 24
             if self.isAttachmentButton {
                 self.layer.cornerRadius = 18
             }

--- a/BChat/Conversations/Input View/InputViewButton.swift
+++ b/BChat/Conversations/Input View/InputViewButton.swift
@@ -11,6 +11,7 @@ final class InputViewButton : UIView {
     private var longPressTimer: Timer?
     private var isLongPress = false
     private let isPayButton: Bool
+    private let isAttachmentButton: Bool
     
     // MARK: UI Components
     private lazy var backgroundView = UIView()
@@ -23,7 +24,8 @@ final class InputViewButton : UIView {
     static let iconSize: CGFloat = 20
     
     // MARK: Lifecycle
-    init(icon: UIImage, isSendButton: Bool = false, delegate: InputViewButtonDelegate, hasOpaqueBackground: Bool = false, isPayButton: Bool = false) {
+    init(icon: UIImage, isSendButton: Bool = false, delegate: InputViewButtonDelegate, hasOpaqueBackground: Bool = false, isPayButton: Bool = false, isAttachmentButton: Bool = false) {
+        self.isAttachmentButton = isAttachmentButton
         self.icon = icon
         self.isSendButton = isSendButton
         self.delegate = delegate
@@ -62,6 +64,9 @@ final class InputViewButton : UIView {
         addSubview(backgroundView)
         backgroundView.pin(to: self)
         layer.cornerRadius = isSendButton ? 24 : 24//isSendButton ? 20 : 6
+        if isAttachmentButton {
+            layer.cornerRadius = 18
+        }
         layer.masksToBounds = true
         isUserInteractionEnabled = true
         widthConstraint.isActive = true
@@ -92,6 +97,9 @@ final class InputViewButton : UIView {
             self.layoutIfNeeded()
             self.frame = frame
             self.layer.cornerRadius = self.isSendButton ? 24 : 24//self.isSendButton ? 20 : 7
+            if self.isAttachmentButton {
+                self.layer.cornerRadius = 18
+            }
             let glowConfiguration = UIView.CircularGlowConfiguration(size: size, color: glowColor, isAnimated: true, radius: isLightMode ? 4 : 6)
             self.setCircularGlow(with: glowConfiguration)
             self.backgroundView.backgroundColor = backgroundColor

--- a/BChat/Home/Views/HomeVC.swift
+++ b/BChat/Home/Views/HomeVC.swift
@@ -558,7 +558,6 @@ final class HomeVC : BaseVC {
             self.threadsForMessageRequest.update(with: transaction)
         }
         threadViewModelCacheForMessageRequest.removeAll()
-        messageCollectionView.reloadData()
     }
     
     private func updateContactAndThread(thread: TSThread, with transaction: YapDatabaseReadWriteTransaction, onComplete: ((Bool) -> ())? = nil) {
@@ -790,8 +789,6 @@ final class HomeVC : BaseVC {
         AssertIsOnMainThread()
         reloadForMessageRequest()
         reload()
-        self.tableView.reloadData()
-        self.messageCollectionView.reloadData()
     }
     
     @objc private func handleProfileDidChangeNotification(_ notification: Notification) {

--- a/BChat/Meta/Images.xcassets/ic_download.imageset/Contents.json
+++ b/BChat/Meta/Images.xcassets/ic_download.imageset/Contents.json
@@ -1,23 +1,26 @@
 {
   "images" : [
     {
-      "idiom" : "universal",
       "filename" : "download-24@1x.png",
+      "idiom" : "universal",
       "scale" : "1x"
     },
     {
-      "idiom" : "universal",
       "filename" : "download-24@2x.png",
+      "idiom" : "universal",
       "scale" : "2x"
     },
     {
-      "idiom" : "universal",
       "filename" : "download-24@3x.png",
+      "idiom" : "universal",
       "scale" : "3x"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/BChat/Onboarding/SignIn/BChatSettingsNewVC.swift
+++ b/BChat/Onboarding/SignIn/BChatSettingsNewVC.swift
@@ -416,10 +416,23 @@ class BChatSettingsNewVC: BaseVC, UITableViewDataSource, UITableViewDelegate {
                 style: .default,
                 handler: { action in
                     print("User tapped Yes")
-                    let vc = NewPasswordVC()
-                    vc.isGoingHome = true
-                    vc.isVerifyPassword = true
-                    self.navigationController!.pushViewController(vc, animated: true)
+                    if SaveUserDefaultsData.WalletPassword.isEmpty {
+                        let viewController = NewPasswordVC()
+                        viewController.isGoingPopUp = true
+                        viewController.isGoingWallet = true
+                        viewController.isCreateWalletPassword = true
+                        self.navigationController?.pushViewController(viewController, animated: true)
+                    } else {
+                        let viewController = NewPasswordVC()
+                        viewController.isGoingWallet = true
+                        viewController.isVerifyWalletPassword = true
+                        self.navigationController!.pushViewController(viewController, animated: true)
+                    }
+                    // Don't Delete
+//                    let vc = NewPasswordVC()
+//                    vc.isGoingHome = true
+//                    vc.isVerifyPassword = true
+//                    self.navigationController!.pushViewController(vc, animated: true)
                 }
             )
             alertController.addAction(yesAction)

--- a/BChat/Onboarding/SignIn/BChatSettingsNewVC.swift
+++ b/BChat/Onboarding/SignIn/BChatSettingsNewVC.swift
@@ -53,6 +53,7 @@ class BChatSettingsNewVC: BaseVC, UITableViewDataSource, UITableViewDelegate {
     
     
     override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
         tableView.reloadData()
     }
     
@@ -415,19 +416,15 @@ class BChatSettingsNewVC: BaseVC, UITableViewDataSource, UITableViewDelegate {
                 title: NSLocalizedString("Setup", comment: "Setup button title"),
                 style: .default,
                 handler: { action in
-                    print("User tapped Yes")
+                    let viewController = NewPasswordVC()
+                    viewController.isGoingWallet = true
                     if SaveUserDefaultsData.WalletPassword.isEmpty {
-                        let viewController = NewPasswordVC()
                         viewController.isGoingPopUp = true
-                        viewController.isGoingWallet = true
                         viewController.isCreateWalletPassword = true
-                        self.navigationController?.pushViewController(viewController, animated: true)
                     } else {
-                        let viewController = NewPasswordVC()
-                        viewController.isGoingWallet = true
                         viewController.isVerifyWalletPassword = true
-                        self.navigationController!.pushViewController(viewController, animated: true)
                     }
+                    self.navigationController!.pushViewController(viewController, animated: true)
                     // Don't Delete
 //                    let vc = NewPasswordVC()
 //                    vc.isGoingHome = true


### PR DESCRIPTION
… while on screen keyboard showing time, the custom open url popup got hided behind that on screen keyboard 	2.If i click the URL than navigate to three dot menu then came back to chat screen, open url and copy button got hided by the text box, BCI-655 -Chat screen: icon color code is different for save in more options while click and hold any attachments, BCI-656 -Sometimes App is getting crash at the time of start receiving first old message in the restore account flow,  BCI-657 -If i enable pay as you chat for the first without going to the my wallet screen, it not asking for setup the pin instead it directly navigate to pin number screen and using the pin number has been set while creating the account,  BCI-658 -Chat screen --> attachments icons: background radius of the attachments option looks different while try open that second time       Test Step: 	1.Click the attachment icon in the text of the chat screen 	2.select any option in that 	3.then came back to chat screen after going to the selected option 	4.Now again click the attachments icon 	5.Now see the background radius of the previously selected option