### PR TITLE
Batch testing bugfixes

### DIFF
--- a/BChat/Conversations/ConversationVC+Interaction.swift
+++ b/BChat/Conversations/ConversationVC+Interaction.swift
@@ -176,7 +176,7 @@ extension ConversationVC : InputViewDelegate, MessageCellDelegate, ContextMenuAc
         sendAttachments(attachments, with: messageText ?? "") { [weak self] in
             self?.dismiss(animated: true, completion: nil)
         }
-        
+        self.dismiss(animated: true, completion: nil)
         scrollToBottom(isAnimated: false)
         resetMentions()
         self.snInputView.text = ""
@@ -1550,8 +1550,14 @@ extension ConversationVC {
                         return promise
                     }
                     .map { _ in
-                        if self?.presentedViewController is ModalActivityIndicatorViewController {
-                            self?.dismiss(animated: true, completion: nil) // Dismiss the loader
+                        DispatchQueue.main.async {
+                            if self?.presentedViewController is ModalActivityIndicatorViewController {
+                                Storage.writeSync { transaction in
+                                    let infoMessage = TSInfoMessage(timestamp: timestamp - 1, in: thread!, messageType: .messageRequestAcceptedByYou, customMessage: "You have accepted the message request")
+                                    infoMessage.save(with: transaction)
+                                }
+                                self?.dismiss(animated: true, completion: nil) // Dismiss the loader
+                            }
                         }
                     }
             }

--- a/BChat/Conversations/ConversationVC+Interaction.swift
+++ b/BChat/Conversations/ConversationVC+Interaction.swift
@@ -214,6 +214,7 @@ extension ConversationVC : InputViewDelegate, MessageCellDelegate, ContextMenuAc
     }
     
     func handleGIFButtonTapped() {
+        self.hideInputAccessoryView()
         if SSKPreferences.isGifPermissionEnabled {
             if NetworkReachabilityStatus.isConnectedToNetworkSignal() {
                 let gifVC = GifPickerViewController(thread: thread)
@@ -223,6 +224,7 @@ extension ConversationVC : InputViewDelegate, MessageCellDelegate, ContextMenuAc
                 present(navController, animated: true) {
                     self.isInputViewShow = false
                 }
+                self.showInputAccessoryView()
             } else {
                 self.showToast(message: "Please check your internet connection", seconds: 1.0)
             }
@@ -1515,9 +1517,6 @@ extension ConversationVC {
         
         return Promise.value(())
             .then { [weak self] _ -> Promise<Void> in
-                if !contact.isApproved {
-                    return Promise.value(())
-                }
                 guard !isNewThread else { return Promise.value(()) }
                 guard let strongSelf = self else {
                     return Promise(error: MessageSender.Error.noThread)
@@ -1552,11 +1551,11 @@ extension ConversationVC {
                     .map { _ in
                         DispatchQueue.main.async {
                             if self?.presentedViewController is ModalActivityIndicatorViewController {
-                                Storage.writeSync { transaction in
-                                    let infoMessage = TSInfoMessage(timestamp: timestamp - 1, in: thread!, messageType: .messageRequestAcceptedByYou, customMessage: "You have accepted the message request")
-                                    infoMessage.save(with: transaction)
-                                }
                                 self?.dismiss(animated: true, completion: nil) // Dismiss the loader
+                            }
+                            Storage.writeSync { transaction in
+                                let infoMessage = TSInfoMessage(timestamp: timestamp - 1, in: thread!, messageType: .messageRequestAcceptedByYou, customMessage: "You have accepted the message request")
+                                infoMessage.save(with: transaction)
                             }
                         }
                     }

--- a/BChat/Conversations/Message Cells/VisibleMessageCell.swift
+++ b/BChat/Conversations/Message Cells/VisibleMessageCell.swift
@@ -542,7 +542,7 @@ final class VisibleMessageCell : MessageCell, LinkPreviewViewDelegate {
 
                     let isOverLapping = isOverlapping(view1: bodyTextView, view2: messageTimeRightLabel)
                     guard let message = viewItem.interaction as? TSMessage else { preconditionFailure() }
-                    if widthOfLastLine < 190 /*message.body?.count ?? 0 < 25*/ && viewItem.quotedReply == nil  && !isOverLapping {
+                    if widthOfLastLine < 190 && viewItem.quotedReply == nil  && !isOverLapping || message.body?.count ?? 0 <= 26 {
                         messageTimeBottomLabel.text = ""
                         messageTimeBottomLabel.isHidden = true
                         
@@ -560,7 +560,7 @@ final class VisibleMessageCell : MessageCell, LinkPreviewViewDelegate {
                         messageTimeRightLabel.text = description
                         
                         
-                        if message.body?.count ?? 0 < 26 {
+                        if message.body?.count ?? 0 <= 26 {
                             let stackViewForMessageAndTime = UIStackView(arrangedSubviews: [])
                             stackViewForMessageAndTime.axis = .horizontal
                             stackViewForMessageAndTime.spacing = 5
@@ -648,7 +648,7 @@ final class VisibleMessageCell : MessageCell, LinkPreviewViewDelegate {
                     // Body text view
                     if let message = viewItem.interaction as? TSMessage, let body = message.body, body.count > 0 {
                         bubbleViewBottomConstraint.isActive = false
-                        bubbleViewBottomConstraint = snContentView.pin(.bottom, to: .bottom, of: bubbleView, withInset: 0)
+                        bubbleViewBottomConstraint = body.count < 18 ? snContentView.pin(.bottom, to: .bottom, of: bubbleView, withInset: 0) : snContentView.pin(.bottom, to: .bottom, of: bubbleView, withInset: -8)
                         let inset: CGFloat = 12
                         let maxWidth = size.width - 2 * inset
                         let bodyTextView = VisibleMessageCell.getBodyTextView(for: viewItem, with: maxWidth - 20, textColor: bodyLabelTextColor, delegate: self, lastString: lastSearchedText)

--- a/BChat/Home/Views/HomeVC.swift
+++ b/BChat/Home/Views/HomeVC.swift
@@ -727,10 +727,11 @@ final class HomeVC : BaseVC {
     
     func threadForMessageRequest(at index: Int) -> TSThread? {
         var thread: TSThread? = nil
-        
         dbConnection.read { transaction in
-            let ext: YapDatabaseViewTransaction? = transaction.ext(TSThreadDatabaseViewExtensionName) as? YapDatabaseViewTransaction
-            thread = ext?.object(atRow: UInt(index), inSection: 0, with: self.threads) as? TSThread
+            guard let ext = transaction.ext(TSThreadDatabaseViewExtensionName) as? YapDatabaseViewTransaction else { return }
+            let count = self.threadsForMessageRequest.numberOfItems(inGroup: TSMessageRequestGroup)
+            let reversedIndex = Int(count) - 1 - index
+            thread = ext.object(atRow: UInt(reversedIndex), inSection: 0, with: self.threads) as? TSThread
         }
         return thread
     }

--- a/BChat/Meta/Translations/en.lproj/Localizable.strings
+++ b/BChat/Meta/Translations/en.lproj/Localizable.strings
@@ -669,6 +669,7 @@
 "modal_pay_as_you_chat_permission_request_title" = "Pay As You Chat";
 "modal_pay_as_you_chat_permission_request_explanation" = "To disable pay as you chat, go to Settings -> Wallet Settings -> Pay As You Chat to use this option";
 "vc_ok_title" = "Ok";
+"MESSAGE_REQUESTS_ACCEPTED_BY_YOU" = "You have accepted the message request";
 
 /* LandingNewVC */
 "CREATE_ACCOUNT_NEW" = "Create Account";

--- a/BChat/Onboarding/New Design/NewIncomingCallVC.swift
+++ b/BChat/Onboarding/New Design/NewIncomingCallVC.swift
@@ -732,6 +732,7 @@ final class NewIncomingCallVC: BaseVC, VideoPreviewDelegate, RTCVideoViewDelegat
         self.bChatCall.hasStartedConnectingDidChange = {
             DispatchQueue.main.async {
                 self.callDurationLabel.text = "Connecting..."
+                self.setAudioOutputToBluetoothOrSpeaker()
                 NotificationCenter.default.post(name: .callConnectingTapNotification, object: nil)
                 UIView.animate(withDuration: 0.5, delay: 0, usingSpringWithDamping: 1, initialSpringVelocity: 1, options: .curveEaseIn, animations: {
                 }, completion: nil)

--- a/BChat/Onboarding/New Design/NewMessageRequestVC.swift
+++ b/BChat/Onboarding/New Design/NewMessageRequestVC.swift
@@ -506,10 +506,20 @@ extension NewMessageRequestVC {
                         return promise
                     }
                     .map { _ in
-                        if self?.presentedViewController is ModalActivityIndicatorViewController {
-                            self?.dismiss(animated: true, completion: nil) // Dismiss the loader
-                            let conversationVC = ConversationVC(thread: thread!)
-                            self?.navigationController?.pushViewController(conversationVC, animated: true)
+                        DispatchQueue.main.async {
+                            if self?.presentedViewController is ModalActivityIndicatorViewController {
+                                self?.dismiss(animated: true) {
+                                    let conversationVC = ConversationVC(thread: thread!)
+                                    self?.navigationController?.pushViewController(conversationVC, animated: true)
+                                }
+                            } else {
+                                let conversationVC = ConversationVC(thread: thread!)
+                                self?.navigationController?.pushViewController(conversationVC, animated: true)
+                            }
+                            Storage.writeSync { transaction in
+                                let infoMessage = TSInfoMessage(timestamp: timestamp - 1, in: thread!, messageType: .messageRequestAcceptedByYou, customMessage: "You have accepted the message request")
+                                infoMessage.save(with: transaction)
+                            }
                         }
                     }
             }

--- a/BChatMessagingKit/Messages/Signal/TSInfoMessage.h
+++ b/BChatMessagingKit/Messages/Signal/TSInfoMessage.h
@@ -18,6 +18,7 @@ typedef NS_ENUM(NSInteger, TSInfoMessageType) {
     TSInfoMessageTypeMediaSavedNotification,
     TSInfoMessageTypeCall,
     TSInfoMessageTypeGroupCurrentUserRemoved,
+    TSInfoMessageTypeMessageRequestAcceptedByYou,
     TSInfoMessageTypeMessageRequestAccepted = 99 // Avoid conficts wit TSInfoMessageTypeCall
 };
 

--- a/BChatMessagingKit/Messages/Signal/TSInfoMessage.m
+++ b/BChatMessagingKit/Messages/Signal/TSInfoMessage.m
@@ -146,6 +146,8 @@ NSUInteger TSInfoMessageSchemaVersion = 1;
             return [self getCallMessagePreviewTextWithTransaction:transaction];
         case TSInfoMessageTypeMessageRequestAccepted:
             return NSLocalizedString(@"MESSAGE_REQUESTS_ACCEPTED", @"");
+        case TSInfoMessageTypeMessageRequestAcceptedByYou:
+            return NSLocalizedString(@"MESSAGE_REQUESTS_ACCEPTED_BY_YOU", @"");
         case TSInfoMessageTypeGroupCurrentUserRemoved:
             return NSLocalizedString(@"YOU_WERE_REMOVED", @"");
         default:


### PR DESCRIPTION
- The timestamp sometimes overlaps with the text when the user sends a single-line message.
- The timestamp sometimes overlaps with the message text, and there is insufficient spacing when the user sends attachments along with the text.
- When the user clicks the GIF option for the first time while the on-screen keyboard is enabled, the text box appears along with the search popup.
- The timestamp position appears mismatch when the user sends multi-line messages.
- If user send a reply message directly without accepting the request, "you have accepted the request " control message is coming after the message which is send by user
- While making a call, I turned on the speaker, but it automatically turned off after the other user answered
