### PR TITLE
fixed audio recording ui issue and message long press ui issue

### DIFF
--- a/BChat/Conversations/Context Menu/ContextMenuVC.swift
+++ b/BChat/Conversations/Context Menu/ContextMenuVC.swift
@@ -102,7 +102,7 @@ final class ContextMenuVC : UIViewController {
         view.addSubview(snapshot)
 //        snapshot.pin(.left, to: .left, of: view, withInset: frame.origin.x)
         if snapshot.height() > (UIScreen.main.bounds.height / 2 - 150) {
-            snapshot.centerWithInset(.vertical, in: view, inset: 20)
+            snapshot.centerWithInset(.vertical, in: view, inset: 0)
         } else {
             if UIScreen.main.bounds.height - frame.origin.y < 120 {
                 snapshot.pin(.top, to: .top, of: view, withInset: frame.origin.y - 100)
@@ -118,14 +118,14 @@ final class ContextMenuVC : UIViewController {
         }
 //        snapshot.set(.width, to: frame.width)
 //        snapshot.set(.height, to: frame.height)
-        if snapshot.height > 500 {
+        if snapshot.height > 450 {
             if frame.origin.x < 30 {
                 snapshot.pin(.left, to: .left, of: view, withInset: frame.origin.x)
             } else {
                 snapshot.pin(.left, to: .left, of: view, withInset: (UIScreen.main.bounds.width/2) - 16)
             }
             snapshot.set(.width, to: UIScreen.main.bounds.width/2)
-            snapshot.set(.height, to: 500)
+            snapshot.set(.height, to: 450)
         } else {
             snapshot.pin(.left, to: .left, of: view, withInset: frame.origin.x)
             snapshot.set(.width, to: frame.width)
@@ -161,7 +161,7 @@ final class ContextMenuVC : UIViewController {
         menuView.set(.height, to: CGFloat(actionViews.count) * 33)
         //let margin = max(UIApplication.shared.connectedScenes.flatMap { ($0 as? UIWindowScene)?.windows ?? [] }.last { $0.isKeyWindow }?.safeAreaInsets.bottom ?? 0, Values.mediumSpacing)
         let margin = max(UIWindow.keyWindow?.safeAreaInsets.bottom  ?? 0, Values.mediumSpacing)
-        if frame.maxY + spacing + menuHeight > UIScreen.main.bounds.height - margin {
+        if frame.maxY + spacing + menuHeight > UIScreen.main.bounds.height - margin && snapshot.height < 450 {
             menuView.pin(.bottom, to: .top, of: snapshot, withInset: -spacing)
             emojiBarView.pin(.top, to: .bottom, of: snapshot, withInset: spacing)
         } else {

--- a/BChat/Conversations/Input View/VoiceMessageRecordingView.swift
+++ b/BChat/Conversations/Input View/VoiceMessageRecordingView.swift
@@ -195,6 +195,7 @@ final class VoiceMessageRecordingView : UIView {
         recordingTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { [weak self] _ in
             self?.updateDurationLabel()
         }
+        RunLoop.main.add(recordingTimer!, forMode: .common)
     }
 
     override init(frame: CGRect) {
@@ -285,10 +286,12 @@ final class VoiceMessageRecordingView : UIView {
 
     // MARK: Updating
     @objc private func updateDurationLabel() {
-        timerSecond += 1
-        let interval = Date().timeIntervalSince(recordingStartDate)
-        durationLabel.text = OWSFormat.formatDurationSeconds(Int(interval))
-        audioDurationLabel.text = OWSFormat.formatDurationSeconds(Int(interval))
+        DispatchQueue.main.async {
+            self.timerSecond += 1
+            let interval = Date().timeIntervalSince(self.recordingStartDate)
+            self.durationLabel.text = OWSFormat.formatDurationSeconds(Int(interval))
+            self.audioDurationLabel.text = OWSFormat.formatDurationSeconds(Int(interval))
+        }
         
         // For Resume Audio Don't Delete
 //        getSecondsIntoMinutesAndSecondFormate(seconds: self.timerSecond) { minutes, seconds in


### PR DESCRIPTION
-If user long press any lengthy paragraph message , the delete option is not clearly visible. 
-If user long press any attachments with lengthy paragraph message more options popup not fully visible
-If user record any audio message and then scroll the old messages in that chats, audio message recording timer got passed and then gets resumes if user stops scrolling