### PR TITLE
Fix: Mention highlighting and multi-line formatting issues in Chat & Secret group screens

### DIFF
--- a/BChat/Conversations/ConversationVC+Interaction.swift
+++ b/BChat/Conversations/ConversationVC+Interaction.swift
@@ -731,13 +731,13 @@ extension ConversationVC : InputViewDelegate, MessageCellDelegate, ContextMenuAc
                 attributedString.addAttribute(.foregroundColor, value: mentionColor, range: range)
             }
         }
-        
-        if let typingRegex = try? NSRegularExpression(pattern: "(?<!\\S)@[^\\s]+", options: []) {
+      // Don't Remove this lines
+        /*if let typingRegex = try? NSRegularExpression(pattern: "(?<!\\S)@[^\\s]+", options: []) {
             typingRegex.enumerateMatches(in: text, options: [], range: fullRange) { match, _, _ in
                 guard let range = match?.range, range.location != NSNotFound else { return }
                 attributedString.addAttribute(.foregroundColor, value: mentionColor, range: range)
             }
-        }
+        }*/
         
         UIView.performWithoutAnimation {
             let selectedRange = snInputView.inputTextView.selectedRange

--- a/BChat/Conversations/Input View/InputTextView.swift
+++ b/BChat/Conversations/Input View/InputTextView.swift
@@ -117,15 +117,6 @@ public final class InputTextView : UITextView, UITextViewDelegate {
     
     public func textViewDidChange(_ textView: UITextView) {
         placeholderLabel.isHidden = !textView.text.isEmpty
-        applyCurrentTextFormatting()
-        handleTextChanged()
-    }
-    
-    public func applyCurrentTextFormatting() {
-        applyFormatting(to: self)
-    }
-    
-    private func applyFormatting(to textView: UITextView) {
         
         // Restore caret and scroll range to visible (no flicker)
         let selectedRange = textView.selectedRange
@@ -148,6 +139,7 @@ public final class InputTextView : UITextView, UITextViewDelegate {
         // Force quote stripe redraw for the just-typed state (e.g. exactly "> ").
         textView.layoutManager.ensureLayout(for: textView.textContainer)
         textView.setNeedsDisplay()
+        handleTextChanged()
     }
     
    public func textView(_ textView: UITextView,
@@ -300,7 +292,10 @@ public final class InputTextView : UITextView, UITextViewDelegate {
     
     private func drawBlockQuoteBars() {
         guard let attributed = attributedText, attributed.length > 0 else { return }
+        self.layoutManager.ensureLayout(for: self.textContainer)
         let fullRange = NSRange(location: 0, length: attributed.length)
+        layoutIfNeeded()
+        let heightOfText = contentSize.height
         
         attributed.enumerateAttribute(.snBlockQuote, in: fullRange, options: []) { value, range, _ in
             guard let isQuote = value as? Bool, isQuote, range.length > 0 else { return }
@@ -309,7 +304,7 @@ public final class InputTextView : UITextView, UITextViewDelegate {
             self.layoutManager.enumerateLineFragments(forGlyphRange: glyphRange) { _, usedRect, _, _, _ in
                 let barX = self.textContainerInset.left + self.textContainer.lineFragmentPadding - self.contentOffset.x + 2
                 let barY = usedRect.minY + self.textContainerInset.top - self.contentOffset.y + 1
-                let barHeight = max(usedRect.height + 1, 5)
+                let barHeight = max(heightOfText + 1, 5)
                 let barRect = CGRect(x: barX, y: barY, width: 3, height: barHeight)
                 let path = UIBezierPath(roundedRect: barRect, cornerRadius: 1.5)
                 UIColor.systemGray.setFill()

--- a/BChat/Conversations/Input View/InputView.swift
+++ b/BChat/Conversations/Input View/InputView.swift
@@ -34,7 +34,7 @@ final class InputView : UIView, InputViewButtonDelegate, InputTextViewDelegate, 
         get { inputTextView.text }
         set {
             inputTextView.text = newValue
-            inputTextView.applyCurrentTextFormatting()
+            inputTextView.textViewDidChange(inputTextView)
         }
     }
     

--- a/BChat/Meta/BChat Utilities/Extension/String + Ext.swift
+++ b/BChat/Meta/BChat Utilities/Extension/String + Ext.swift
@@ -184,8 +184,8 @@ extension NSMutableAttributedString {
     
     func addAttributesPreservingColor(clearText: Bool) {
         
-        // MARK: - Code block
-        applyPatternPreservingColor("```([\\s\\S]+?)```", clearText: clearText) { range in
+        // MARK: - Monospace
+        applyPatternPreservingColor("(?<!\\w)```([^\\s][\\s\\S]*[^\\s])```(?!\\w)", clearText: clearText) { range in
             let mono = UIFont.monospacedSystemFont(
                 ofSize: font(at: range.location).pointSize,
                 weight: .regular
@@ -194,7 +194,7 @@ extension NSMutableAttributedString {
         }
         
         // MARK: - Inline code
-        applyPatternPreservingColor("`([^\\s`][^`]*?)`", clearText: clearText) { range in
+        applyPatternPreservingColor("(?<![`\\w])`([^\\s`\\n](?:[^`\\n]*[^\\s`\\n])?)`(?![`\\w])", clearText: clearText) { range in
             let mono = UIFont.monospacedSystemFont(
                 ofSize: font(at: range.location).pointSize,
                 weight: .regular
@@ -204,35 +204,20 @@ extension NSMutableAttributedString {
         }
         
         // MARK: - Bold, Italic, Strikethrough
-        applyPatternPreservingColor("\\*(\\S(?:.*?\\S)?)\\*", clearText: clearText) { range in
+        applyPatternPreservingColor("\\*(\\S(?:[^\\n]*?\\S)?)\\*", clearText: clearText) { range in
             self.addFontTraitPreservingExistingTraits(.traitBold, in: range)
         }
         
-        applyPatternPreservingColor("_(\\S(?:.*?\\S)?)_", clearText: clearText) { range in
+        applyPatternPreservingColor("_(\\S(?:[^\\n]*?\\S)?)_", clearText: clearText) { range in
             self.addFontTraitPreservingExistingTraits(.traitItalic, in: range)
         }
         
-        applyPatternPreservingColor("~(\\S(?:.*?\\S)?)~", clearText: clearText) { range in
+        applyPatternPreservingColor("~(\\S(?:[^\\n]*?\\S)?)~", clearText: clearText) { range in
             self.addAttribute(.strikethroughStyle, value: 1, range: range)
         }
         
         // MARK: - Quotes
         applyQuotes(clearText: clearText)
-        
-        // MARK: - ONLY SEND FIX (greedy override)
-        if clearText {
-            applyGreedyOverride(marker: "*", clearText: clearText) { range in
-                self.addFontTraitPreservingExistingTraits(.traitBold, in: range)
-            }
-            
-            applyGreedyOverride(marker: "_", clearText: clearText) { range in
-                self.addFontTraitPreservingExistingTraits(.traitItalic, in: range)
-            }
-            
-            applyGreedyOverride(marker: "~", clearText: clearText) { range in
-                self.addAttribute(.strikethroughStyle, value: 1, range: range)
-            }
-        }
     }
     
     private func applyGreedyOverride(


### PR DESCRIPTION
- Mention highlighting issue on new lines and bullet points in Secret Group Chat
- Keep text formatting same for multi-line messages in input bar and after sending
- Inconsistent mention formatting in multi-line messages
- Resolve delayed mention highlighting until extra input/space is added
- Incorrect highlighting when text is typed with mention without space
- Block quote view not appearing in input bar after 4+ lines
- Incorrect rendering of nested text formatting (e.g., bold + italic)
- Mention tagging not working inside formatting symbols (e.g., *, _, ~)