### PR TITLE
Text formatting bug fixes

### DIFF
--- a/BChat/Conversations/Input View/InputTextView.swift
+++ b/BChat/Conversations/Input View/InputTextView.swift
@@ -395,10 +395,15 @@ public final class InputTextView : UITextView, UITextViewDelegate {
     
     private func drawBlockQuoteBars() {
         guard let attributed = attributedText, attributed.length > 0 else { return }
+        let nsText = attributed.string as NSString
         let fullRange = NSRange(location: 0, length: attributed.length)
         
         attributed.enumerateAttribute(.snBlockQuote, in: fullRange, options: []) { value, range, _ in
             guard let isQuote = value as? Bool, isQuote, range.length > 0 else { return }
+            if range.location + 3 <= nsText.length {
+                let prefix = nsText.substring(with: NSRange(location: range.location, length: 3))
+                if prefix == ">  " { return }
+            }
             
             let glyphRange = self.layoutManager.glyphRange(forCharacterRange: range, actualCharacterRange: nil)
             self.layoutManager.ensureLayout(forGlyphRange: glyphRange)

--- a/BChat/Conversations/Input View/InputTextView.swift
+++ b/BChat/Conversations/Input View/InputTextView.swift
@@ -158,6 +158,9 @@ public final class InputTextView : UITextView, UITextViewDelegate {
    public func textView(_ textView: UITextView,
                   shouldChangeTextIn range: NSRange,
                         replacementText text: String) -> Bool {
+       if revertBulletIfTypingBefore(textView, range: range, replacementText: text) {
+           return false
+       }
        
        // Handle ENTER (already done before)
        if text == "\n" {
@@ -205,7 +208,7 @@ public final class InputTextView : UITextView, UITextViewDelegate {
            
            // Continue bullet if valid text exists
            for prefix in bulletPrefixes {
-               if trimmed.hasPrefix(prefix + " ") {
+               if lineText.hasPrefix(prefix + " ") && !lineText.hasPrefix(prefix + "  ") {
                    let insertion = "\n\(prefix) "
                    textView.text = nsText.replacingCharacters(in: range, with: insertion)
                    textView.selectedRange = NSRange(location: range.location + insertion.count, length: 0)
@@ -235,6 +238,41 @@ public final class InputTextView : UITextView, UITextViewDelegate {
        return true
    }
     
+    private func revertBulletIfTypingBefore(_ textView: UITextView, range: NSRange, replacementText text: String) -> Bool {
+        guard !text.isEmpty else { return false }
+
+        let nsText = textView.text as NSString
+        let lineRange = nsText.lineRange(for: range)
+
+        guard lineRange.location + 2 <= nsText.length else { return false }
+
+        let prefixRange = NSRange(location: lineRange.location, length: 2)
+        let prefix = nsText.substring(with: prefixRange)
+
+        // Only act if line starts with bullet
+        guard prefix == "• " else { return false }
+
+        // If user is typing BEFORE bullet
+        if range.location <= lineRange.location {
+            let marker = bulletMarkerByLineStart[lineRange.location] ?? "-"
+            let newPrefix = "\(text)\(marker) "
+
+            if let replaceRange = Range(prefixRange, in: textView.text) {
+                textView.text.replaceSubrange(replaceRange, with: newPrefix)
+
+                // Adjust cursor position
+                let newCursor = range.location + (newPrefix.count - 2)
+                textView.selectedRange = NSRange(location: max(0, newCursor), length: 0)
+
+                bulletMarkerByLineStart.removeValue(forKey: lineRange.location)
+                textViewDidChange(textView)
+                return true
+            }
+        }
+
+        return false
+    }
+    
     private func handleBulletStart(_ textView: UITextView, range: NSRange) -> Bool {
         let nsText = textView.text as NSString
         let lineRange = nsText.lineRange(for: range)
@@ -246,8 +284,15 @@ public final class InputTextView : UITextView, UITextViewDelegate {
         // Get text before cursor
         let prefix = nsText.substring(with: NSRange(location: lineRange.location, length: cursorPosition))
         
-        if prefix == "*" || prefix == "-" {
-            if cursorPosition != 1 { return false }
+        if (prefix == "*" || prefix == "-") && cursorPosition == 1 {
+            // Ensure nothing exists before marker (no spaces)
+            if lineRange.location < nsText.length {
+                let fullLinePrefix = nsText.substring(with: NSRange(location: lineRange.location, length: cursorPosition))
+                if fullLinePrefix.hasPrefix(" ") {
+                    return false
+                }
+            }
+
             bulletMarkerByLineStart[lineRange.location] = prefix
             replaceCurrentLinePrefix(textView, lineRange: lineRange, prefixLength: 1)
             return true
@@ -343,9 +388,9 @@ public final class InputTextView : UITextView, UITextViewDelegate {
         // Get current line
         let lineRange = nsText.lineRange(for: range)
         let currentLine = nsText.substring(with: lineRange).trimmingCharacters(in: .whitespacesAndNewlines)
-        
+        let numberedLineCheck = nsText.substring(with: lineRange)
         // MARK: Numbered List (1. 2. 3.)
-        if let match = currentLine.range(of: #"^(\d+)\.\s"#, options: .regularExpression) {
+        if let match = numberedLineCheck.range(of: #"^(\d+)\.\s"#, options: .regularExpression) {
             let numberString = String(currentLine[match]).replacingOccurrences(of: ". ", with: "")
             
             if let number = Int(numberString) {
@@ -357,15 +402,8 @@ public final class InputTextView : UITextView, UITextViewDelegate {
         }
         
         // MARK: Bullet List (- * •)
-        if currentLine.hasPrefix("- ") || currentLine.hasPrefix("* ") || currentLine.hasPrefix("• ") {
-            let marker: String
-            if currentLine.hasPrefix("* ") {
-                marker = "*"
-            } else if currentLine.hasPrefix("- ") {
-                marker = "-"
-            } else {
-                marker = bulletMarkerByLineStart[lineRange.location] ?? "-"
-            }
+        if currentLine.hasPrefix("• ") {
+            let marker = bulletMarkerByLineStart[lineRange.location] ?? "-"
             
             let newText = "\n• "
             insertText(newText, textView: textView, range: range)

--- a/BChat/Conversations/Message Cells/Content Views/QuoteView.swift
+++ b/BChat/Conversations/Message Cells/Content Views/QuoteView.swift
@@ -443,25 +443,25 @@ final class QuoteView : UIView {
             let lineLength = (line as NSString).length
             var renderedLength = lineLength
             
-            if line.hasPrefix(">") {
-                let removeLength = line.hasPrefix("> ") ? 2 : 1
-                if removeLength <= lineLength {
-                    attributed.replaceCharacters(
-                        in: NSRange(location: offset, length: removeLength),
-                        with: ""
-                    )
-                    renderedLength = lineLength - removeLength
-                }
+            let isValidSingleSpaceQuote =
+                line.hasPrefix("> ") &&
+                !line.hasPrefix(">  ") &&
+                lineLength >= 3
+            
+            if isValidSingleSpaceQuote {
+                attributed.replaceCharacters(
+                    in: NSRange(location: offset, length: 2),
+                    with: ""
+                )
+                renderedLength = lineLength - 2
                 
-                if renderedLength > 0 {
-                    let quoteRange = NSRange(location: offset, length: renderedLength)
-                    attributed.addAttribute(.snBlockQuote, value: true, range: quoteRange)
-                    
-                    let paragraphStyle = NSMutableParagraphStyle()
-                    paragraphStyle.firstLineHeadIndent = 10
-                    paragraphStyle.headIndent = 10
-                    attributed.addAttribute(.paragraphStyle, value: paragraphStyle, range: quoteRange)
-                }
+                let quoteRange = NSRange(location: offset, length: renderedLength)
+                attributed.addAttribute(.snBlockQuote, value: true, range: quoteRange)
+                
+                let paragraphStyle = NSMutableParagraphStyle()
+                paragraphStyle.firstLineHeadIndent = 10
+                paragraphStyle.headIndent = 10
+                attributed.addAttribute(.paragraphStyle, value: paragraphStyle, range: quoteRange)
             }
             
             offset += renderedLength
@@ -478,11 +478,15 @@ final class QuoteView : UIView {
         
         setupTextKit()
         layoutManager.ensureLayout(for: textContainer)
-
+        let nsText = attributed.string as NSString
         let fullRange = NSRange(location: 0, length: attributed.length)
 
         attributed.enumerateAttribute(.snBlockQuote, in: fullRange, options: []) { value, range, _ in
             guard let isQuote = value as? Bool, isQuote, range.length > 0 else { return }
+            if range.location + 3 <= nsText.length {
+                let prefix = nsText.substring(with: NSRange(location: range.location, length: 3))
+                if prefix == ">  " { return }
+            }
 
             let glyphRange = layoutManager.glyphRange(forCharacterRange: range, actualCharacterRange: nil)
 

--- a/BChat/Conversations/Views & Modals/BodyTextView.swift
+++ b/BChat/Conversations/Views & Modals/BodyTextView.swift
@@ -50,9 +50,14 @@ final class BodyTextView : UITextView {
     private func drawBlockQuoteBars() {
         guard let attributed = attributedText, attributed.length > 0 else { return }
         let fullRange = NSRange(location: 0, length: attributed.length)
+        let nsText = attributed.string as NSString
         
         attributed.enumerateAttribute(.snBlockQuote, in: fullRange, options: []) { value, range, _ in
             guard let isQuote = value as? Bool, isQuote, range.length > 0 else { return }
+            if range.location + 3 <= nsText.length {
+                let prefix = nsText.substring(with: NSRange(location: range.location, length: 3))
+                if prefix == ">  " { return }
+            }
             
             let glyphRange = self.layoutManager.glyphRange(forCharacterRange: range, actualCharacterRange: nil)
             self.layoutManager.enumerateLineFragments(forGlyphRange: glyphRange) { _, usedRect, _, _, _ in

--- a/BChat/Home/Views/Cells/HomeTableViewCell.swift
+++ b/BChat/Home/Views/Cells/HomeTableViewCell.swift
@@ -438,9 +438,11 @@ class HomeTableViewCell: UITableViewCell {
         
         // Group message
         let font = threadViewModel.hasUnreadMessages ? Fonts.regularOpenSans(ofSize: Values.smallFontSize) : Fonts.regularOpenSans(ofSize: Values.smallFontSize)
-        if threadViewModel.isGroupThread, let message = threadViewModel.lastMessageForInbox as? TSMessage, let name = getMessageAuthorName(message: message) {
-            result.append(NSAttributedString(string: "\(name): ", attributes: [ .font : font, .foregroundColor : Colors.textFieldPlaceHolderColor ]))
-        }
+        // Don't Remove Below Code
+        // For Group Thread No Need To Add User Name Before Message
+//        if threadViewModel.isGroupThread, let message = threadViewModel.lastMessageForInbox as? TSMessage, let name = getMessageAuthorName(message: message) {
+//            result.append(NSAttributedString(string: "\(name): ", attributes: [ .font : font, .foregroundColor : Colors.textFieldPlaceHolderColor ]))
+//        }
         
         guard var lastMessageText = threadViewModel.lastMessageText else { return result }
         
@@ -481,7 +483,7 @@ class HomeTableViewCell: UITableViewCell {
         
         for (index, line) in lines.enumerated() {
             let lineLength = (line as NSString).length
-            if line.hasPrefix("> "), lineLength >= 2 {
+            if line.hasPrefix("> "), lineLength >= 2, !line.hasPrefix(">  ") {
                 let quotedText = String(line.dropFirst(2))
                 let replacement = "│ \(quotedText)"
                 let lineRange = NSRange(location: offset, length: lineLength)

--- a/BChat/Meta/BChat Utilities/Extension/String + Ext.swift
+++ b/BChat/Meta/BChat Utilities/Extension/String + Ext.swift
@@ -266,6 +266,7 @@ extension NSMutableAttributedString {
             }
             
             guard line.hasPrefix("> "), lineLength >= 3 else { continue }
+            guard !line.hasPrefix(">  ") else { continue }
             
             let lineRange = NSRange(location: offset, length: lineLength)
             let markerRange = NSRange(location: offset, length: 2)

--- a/BChat/Notifications/AppNotifications.swift
+++ b/BChat/Notifications/AppNotifications.swift
@@ -422,7 +422,7 @@ public class NotificationPresenter: NSObject, NotificationsProtocol {
         
         for (index, line) in lines.enumerated() {
             let lineLength = (line as NSString).length
-            if line.hasPrefix("> "), lineLength >= 2 {
+            if line.hasPrefix("> "), lineLength >= 2, !line.hasPrefix(">  ") {
                 let quotedText = String(line.dropFirst(2))
                 let replacement = "│ \(quotedText)"
                 let range = NSRange(location: offset, length: lineLength)

--- a/SignalUtilitiesKit/Media Viewing & Editing/Attachment Approval/AttachmentTextView.swift
+++ b/SignalUtilitiesKit/Media Viewing & Editing/Attachment Approval/AttachmentTextView.swift
@@ -26,9 +26,14 @@ class AttachmentTextView: UITextView {
     private func drawBlockQuoteBars() {
         guard let attributed = attributedText, attributed.length > 0 else { return }
         let fullRange = NSRange(location: 0, length: attributed.length)
+        let nsText = attributed.string as NSString
         
         attributed.enumerateAttribute(.attachmentBlockQuote, in: fullRange, options: []) { value, range, _ in
             guard let isQuote = value as? Bool, isQuote, range.length > 0 else { return }
+            if range.location + 3 <= nsText.length {
+                let prefix = nsText.substring(with: NSRange(location: range.location, length: 3))
+                if prefix == ">  " { return }
+            }
             
             let glyphRange = self.layoutManager.glyphRange(forCharacterRange: range, actualCharacterRange: nil)
             self.layoutManager.enumerateLineFragments(forGlyphRange: glyphRange) { _, usedRect, _, _, _ in


### PR DESCRIPTION
- Bullet points don’t convert to * or - if any text precedes the list.
- Prevent whitespaces before creating a bullet or numbered list
- After typing “>”, adding two spaces converts the text into a quote format.
- Typing “>” after two or more spaces turns the message into a quote when sent.
- Home Screen: For last message symbol is showing instead of quote for secret group